### PR TITLE
fixes for issue #11: Custom Operation not Updating Automatically When Data Changes, useLiveQuery callbacks with deps never get cleaned up

### DIFF
--- a/bin/generateWebWorker.js
+++ b/bin/generateWebWorker.js
@@ -34,13 +34,13 @@ import {readFile} from 'fs/promises';
     const operationsImportPath = operationsFullPath.replace(/\\/g, '/');
 
     entryFileContent += `import configModule from '${operationsImportPath}';\n`;
-    entryFileContent += `const configs = configModule.default || configModule;\n`;
+    entryFileContent += `const configs = {...(configModule.default || configModule), watch: () => {}};\n`;
   } else {
     // No config file – fall back to a default
     console.warn(
       `Config file "${configPath}" not found. Using default config (no operations).`
     );
-    entryFileContent += `const configs = { operations: [] };\n`;
+    entryFileContent += `const configs = { operations: { watch: () => {} } };\n`;
   }
 
   // Import dexieWorker.js content

--- a/src/createDexieProxy.ts
+++ b/src/createDexieProxy.ts
@@ -131,6 +131,13 @@ function createProxy<T>(
     },
     apply(_target, _thisArg, args: any[]) {
       const lastItem = chain[chain.length - 1];
+      if (lastItem.prop === 'operation' && args[0] === 'watch') {
+        const tableName = args[1];
+        if (typeof tableName === 'string') {
+          tableAccessCallback?.(tableName);
+          return; // No need to create a new proxy for watch operations
+        }
+      }
       let newChain: ChainItem[];
       if (lastItem && lastItem.type === 'get') {
         const methodName = lastItem.prop!;

--- a/src/liveQuery.ts
+++ b/src/liveQuery.ts
@@ -51,5 +51,5 @@ export function liveQuery<T>(querier: (db: any) => Promise<T> | T): Observable<T
       isSubscribed = false;
       removeChangeListener(changeHandler);
     };
-  }).pipe(shareReplay(1));
+  }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 }


### PR DESCRIPTION
This PR fixes the bugs outlined in issue #11 

I added a default custom operation `watch` that does no work but adds the specified table name to `accessedTables`. This allows custom operations can react to live data without adding work to the query.

I also modified the rxjs `Observer.pipe(shareReplay(1))` in `liveQuery.ts` to `.pipe(shareReplay({ bufferSize: 1, refCount: true }))` so that the subscription will not stay alive when there are no longer any subscribers. This prevents queries from executing after the subscription ends.

